### PR TITLE
Resolved a complier warning regarding initialization ordering

### DIFF
--- a/include/csv/dialect.hpp
+++ b/include/csv/dialect.hpp
@@ -38,16 +38,18 @@ SOFTWARE.
 namespace csv {
 
   struct Dialect {
+
     std::string delimiter_;
     bool skip_initial_space_;
-    bool skip_empty_rows_;
     char line_terminator_;
     char quote_character_;
     bool double_quote_;
-    unordered_flat_map<std::string_view, bool> ignore_columns_;
     std::vector<char> trim_characters_;
-    std::vector<std::string> column_names_;
     bool header_;
+    bool skip_empty_rows_;
+      
+    unordered_flat_map<std::string_view, bool> ignore_columns_;
+    std::vector<std::string> column_names_;
 
     Dialect() :
       delimiter_(","),

--- a/include/csv/writer.hpp
+++ b/include/csv/writer.hpp
@@ -235,6 +235,9 @@ private:
     file_stream.close();
   }
 
+  Dialect current_dialect_;
+  bool header_written_;
+ 
   std::ofstream file_stream;
   std::thread thread;
   std::promise<bool> done_promise;
@@ -242,9 +245,9 @@ private:
   ConcurrentQueue<std::string> queue;
   std::string current_dialect_name_;
   unordered_flat_map<std::string, Dialect> dialects_;
-  Dialect current_dialect_;
+
   std::vector<std::string> current_row_entries_;
-  bool header_written_;
+ 
 };
 
 }


### PR DESCRIPTION
Basically, [C.47](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-order) suggests that its better to initialize member variables in the order that they've been declared. This could cause some random issues. 

P.S. Your tests passes, but I noticed that you don't have tests for the writer. 